### PR TITLE
Move Definity Package 2 Package Require Dependencies. Move To Dependencies Object

### DIFF
--- a/.changeset/smooth-days-flash.md
+++ b/.changeset/smooth-days-flash.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/core": 0.0.2
+---
+
+Move "@types/ndarray" & "@types/qr-image" to Dependencies not Dev.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,12 +53,13 @@
     "mutable-buffer": "^2.0.3",
     "ndarray": "^1.0.19",
     "qr-image": "*",
+    "@types/qr-image": "^3.2.4",
+    "@types/ndarray": "^1.0.11",
     "@node-escpos/adapter": "workspace:*"
   },
   "devDependencies": {
     "@types/get-pixels": "^3.3.2",
-    "@types/ndarray": "^1.0.11",
-    "@types/node": "^10.0.0",
-    "@types/qr-image": "^3.2.4"
+    "@types/node": "^10.0.0"
+
   }
 }


### PR DESCRIPTION
Move "@types/ndarray" & "@types/qr-image" to Dependencies not Dev.
but another Function is used