### PR TITLE
Enhance drawLine function with raw buffer possibility

### DIFF
--- a/.changeset/brave-meals-jam.md
+++ b/.changeset/brave-meals-jam.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/core": minor
+---
+
+Added raw buffer possibility for drawLine function

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -200,12 +200,19 @@ export class Printer<AdapterCloseArgs extends []> extends EventEmitter {
 
   /**
    * [function Print draw line End Of Line]
-   * @param  {[String]}  character [optional]
+   * @param  {[Buffer|string]}  character [optional]
    * @return {[Printer]} printer  [the escpos printer instance]
    */
-  drawLine(character = "-") {
+  drawLine(character: Buffer | string = "-") {
+    let buffer: Buffer;
+    // Allow to print hex codes from codepage
+    if (Buffer.isBuffer(character)) {
+      buffer = character;
+    } else {
+      buffer = Buffer.from(character);
+    }
     for (let i = 0; i < this.width; i++)
-      this.buffer.write(Buffer.from(character));
+      this.buffer.write(buffer);
 
     this.newLine();
 


### PR DESCRIPTION
In order to be able to use different character code pages it is necessary to print the raw hex value of a character from the codepage. With this enhancement it is possible to draw a line using the line character ─ from [PC850](https://en.wikipedia.org/wiki/Code_page_850): 

``` JavaScript
printer.setCharacterCodeTable(2);
printer.drawLine(Buffer.from('C4', 'hex'));
printer.setCharacterCodeTable(0);
```