### PR TITLE
Add functionatlity to set international charset

### DIFF
--- a/.changeset/warm-glasses-dream.md
+++ b/.changeset/warm-glasses-dream.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/core": minor
+---
+
+Added functionality to set charset inside the printer

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -316,3 +316,31 @@ export const COLOR = {
   REVERSE: "\x1DB1", // Reverses the colors - white text on black background
   UNREVERSE: "\x1DB0", // Default: undo the reverse - black text on white background
 };
+
+/**
+ * List of available character sets
+ * @type {Object}
+ */
+export const CHARACTER_SET = {
+  TM_T20: {     // Epson TM-T20II
+    US: 0,      // U.S.A
+    FR: 1,      // France
+    DE: 2,      // Germany
+    EN: 3,      // England
+    DK: 4,      // Denmark
+    SE: 5,      // Sweden
+    IT: 6,      // Italy
+    ES: 7,      // Spain
+    JP: 8,      // Japan
+    NO: 9,      // Norway
+    DK_2: 10,   // Denmark II
+    ES_2: 11,   // Spain II
+    LATIN_A: 12,// Latin America
+    KR: 13,     // Korea
+    SI: 14,     // Slovenia
+    HR: 14,     // Croatia
+    CN: 15,     // China
+    VN: 16,     // Vietnam
+    ARABIA: 17  // Arabia
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,18 @@ export class Printer<AdapterCloseArgs extends []> extends EventEmitter {
     this.buffer.writeUInt8(codeTable);
     return this;
   }
+  
+  /**
+   * Set charset
+   * @param  {[Number]} charset
+   * @return {[Printer]} printer  [the escpos printer instance]
+   */
+   setCharset(charset: number = _.CHARACTER_SET.TM_T20.US) {
+    this.buffer.write(_.ESC);
+    this.buffer.write("\x52");
+    this.buffer.writeUInt8(charset);
+    return this;
+  }
 
   /**
    * Fix bottom margin


### PR DESCRIPTION
In order to print different characters based on the language it is necessary to change the charset of the printer.

Usage:
``` Typescript
p.setCharset(CHARACTER_SET.TM_T20.US)
p.text("|");
p.setCharset(CHARACTER_SET.TM_T20.DE)
````

Epson TM-T20 Specification:
![grafik](https://user-images.githubusercontent.com/47447339/206786395-76ee46f6-d7ef-46a3-b340-d3b8bcb30214.png)