### PR TITLE
fix: getStatuses does not reject when data is not returned

### DIFF
--- a/.changeset/forty-items-check.md
+++ b/.changeset/forty-items-check.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/core": minor
+---
+
+getStatuses does not reject when data is not returned

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -913,11 +913,11 @@ export class Printer<AdapterCloseArgs extends []> extends EventEmitter {
    * @return {Promise}
    */
   getStatuses(): Promise<DeviceStatus[]> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.adapter.read((data) => {
         const buffer: number[] = [];
         for (let i = 0; i < data.byteLength; i++) buffer.push(data.readInt8(i));
-        if (buffer.length < 4) return;
+        if (buffer.length < 4) return reject();
 
         const statuses = [
           new PrinterStatus(buffer[0]),


### PR DESCRIPTION
getStatuses does not reject when data is not returned