### PR TITLE
fix: OfflineCauseStatus JSON always shows errors

### DIFF
--- a/.changeset/honest-monkeys-think.md
+++ b/.changeset/honest-monkeys-think.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/core": minor
+---
+
+OfflineCauseStatus JSON always shows errors

--- a/packages/core/src/statuses.ts
+++ b/packages/core/src/statuses.ts
@@ -133,7 +133,7 @@ export class OfflineCauseStatus extends DeviceStatus {
     const result = super.toBaseJSON("OfflineCauseStatus");
     for (let i = 0; i < 8; i++) {
       let label = "";
-      let status = Status.Error;
+      let status = Status.Ok;
       switch (i) {
         case 2:
           if (this.bitsAsc[i] === 1) {


### PR DESCRIPTION
OfflineCauseStatus JSON always shows errors because the status is initialized with 'Status.Error' instead 'Status.Ok' in the loop. 