### PR TITLE
feat: Added getDeviceBySerial function and outsourced isPrinter function

### DIFF
--- a/.changeset/tricky-maps-listen.md
+++ b/.changeset/tricky-maps-listen.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/usb-adapter": minor
+---
+
+Added getDeviceBySerial and outsourced isPrinter function for reusability

--- a/packages/usb-adapter/src/index.ts
+++ b/packages/usb-adapter/src/index.ts
@@ -1,7 +1,8 @@
 import os from "os";
 
 import { Adapter } from "@node-escpos/adapter";
-import { Interface, InEndpoint, OutEndpoint, LibUSBException, findBySerialNumber } from "usb";
+import type { Interface, InEndpoint, OutEndpoint, LibUSBException } from "usb";
+import { findBySerialNumber } from "usb";
 import { usb, getDeviceList, findByIds } from "usb";
 
 /**


### PR DESCRIPTION
Added getDeviceBySerial function which is necessary if multiple printers of the same manufacturer and model are present.

Outsourced isPrinter function for reusability. When listening on usb.on('attach', () => {}) it is useful to be able to reuse the isPrinter() function.