### PR TITLE
feat!: Made list() a static function

### DIFF
--- a/.changeset/short-ads-report.md
+++ b/.changeset/short-ads-report.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/serialport-adapter": major
+---
+
+Changed Serial.list() to be static as it is not bind to the object

--- a/packages/serialport-adapter/src/index.ts
+++ b/packages/serialport-adapter/src/index.ts
@@ -19,10 +19,10 @@ export default class Serial extends Adapter<[timeout?: number]> {
   }
 
   /**
-   * List Printers
+   * List Serial Devices
    * @returns {[Array]}
    */
-  async list() {
+  static async list() {
     const ports: PortInfo[] = await SerialPort.list();
     return ports;
   }


### PR DESCRIPTION
BREAKING CHANGE: list() is now static and not callable from the serial object

It doesn't really make sense to call the list() function if one have already initialized an object with a serial path. The list() function lists possible serial paths and devices. Therefore its use is in my eyes normally before initializing an object with a known path. Also the list() is independend from on the object.