### PR TITLE
fix: spacing for right and center aligned text in tableCustom

### DIFF
--- a/.changeset/neat-numbers-relax.md
+++ b/.changeset/neat-numbers-relax.md
@@ -1,0 +1,5 @@
+---
+"@node-escpos/core": patch
+---
+
+Fix spacing for right and center aligned text in tableCustom

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -308,18 +308,20 @@ export class Printer<AdapterCloseArgs extends []> extends EventEmitter {
       }
 
       if (align === "CENTER") {
-        const spaces = (cellWidth - textLength) / 2;
-        for (let s = 0; s < spaces; s++) lineStr += " ";
+        const spaces = Math.floor(cellWidth - textLength) / 2;
+        const leftSpaces = Math.ceil(spaces);
+        const rightSpaces = Math.floor(spaces);
+        for (let s = 0; s < leftSpaces; s++) lineStr += " ";
 
         if (obj.text !== "") {
           if (obj.style) lineStr += `${this._getStyle(obj.style)}${obj.text}${this._getStyle("NORMAL")}`;
           else lineStr += obj.text;
         }
 
-        for (let s = 0; s < spaces - 1; s++) lineStr += " ";
+        for (let s = 0; s < rightSpaces; s++) lineStr += " ";
       }
       else if (align === "RIGHT") {
-        let spaces = cellWidth - textLength;
+        let spaces = Math.floor(cellWidth - textLength);
         if (leftoverSpace > 0) {
           spaces += leftoverSpace;
           leftoverSpace = 0;


### PR DESCRIPTION
fix https://github.com/node-escpos/driver/issues/62

This PR aims to fix misalignment in certain circumstances when using center and right aligned text. Because the floor of the number of spaces the column had available wasn't taken for right and center as it was for left, these columns had a tendency to overflow and cause extra newlines.

This is fixed by taking the floor of cellWidth - textLength for right aligned text, and handling fractional components by taking the ceiling for the left side and floor for the right side for center aligned text. This keeps the previous convention of preferring extra space on the left instead of right for center aligned text.

An example of bad parameters that would cause issues before this PR for testing purposes is cellWidth = 4.2 and textLength = 2.

Took over maintainence from @jackson-stone-fs at #99.